### PR TITLE
Update definitions.js

### DIFF
--- a/routes/definitions.js
+++ b/routes/definitions.js
@@ -12,10 +12,10 @@ router.get('/', (req, res, next) => {
 router.delete('/:id', (req, res) => {
     res.json({
         message: 'Success!',
-        id: eq.params.id
+        id: req.params.id
     });
 
-    // Definition.findOne({ _id: req.params.myid, owner: req.user})
+    // Definition.findOne({ _id: req.params.id, owner: req.user})
     // .then((definition) => {
     //     definition.remove().then((definition) => {
     //         res.json({


### PR DESCRIPTION
So the :id is the name the req.params object will get so `req.params.id` not id.  and you'll want to use the _id from mongodb if you want to find by _id so it will look like this `http://localhost:3000/api/definitions/59dd74eb8a9fe2111c3e81e8` only your _id will be different